### PR TITLE
Include `LQ` cut

### DIFF
--- a/src/calibrate_all.jl
+++ b/src/calibrate_all.jl
@@ -76,6 +76,7 @@ function calibrate_all(data::LegendData, sel::AnyValiditySelection, datastore::A
         trig_e_535_cal = trig_e_535_cal,
         is_valid_qc = count.(ged_events_pre.is_baseline) .== n_expected_baseline,
         is_valid_hit = is_valid_hit.(getindex.(ged_events_pre.channel, trig_e_ch), Ref(Int.(hitgeds_channels))),
+        is_valid_psd = all.(getindex.(ged_events_pre.psd_classifier, trig_e_ch)),
         is_discharge_recovery = any.(ged_events_pre.is_discharge_recovery_ml),
         is_saturated = any.(ged_events_pre.is_saturated),
         is_discharge = any.(ged_events_pre.is_discharge),

--- a/src/calibrate_geds.jl
+++ b/src/calibrate_geds.jl
@@ -40,7 +40,7 @@ function calibrate_ged_channel_data(data::LegendData, sel::AnyValiditySelection,
     end
     
     # get postcal psd flags
-    postcal_pf = get_ged_aoe_cut_propfunc(data, sel, detector; pars_type=psd_cut_pars_type, pars_cat=psd_cut_pars_cat)
+    aoecut_pf = get_ged_aoe_cut_propfunc(data, sel, detector; pars_type=psd_cut_pars_type, pars_cat=psd_cut_pars_cat)
     
     # apply calibrations 
     cal_output = cal_pf.(chdata)
@@ -51,7 +51,7 @@ function calibrate_ged_channel_data(data::LegendData, sel::AnyValiditySelection,
     cut_output = cut_pf.(cal_chdata)
 
     # get postcal data
-    postcal_data = postcal_pf.(cal_chdata)
+    postcal_data = aoecut_pf.(cal_chdata)
 
     # get additional columns 
     chdata_output = chdata_output_pf.(chdata)

--- a/src/calibrate_geds.jl
+++ b/src/calibrate_geds.jl
@@ -12,7 +12,9 @@ Also calculates the configured cut/flag values.
 """
 function calibrate_ged_channel_data(data::LegendData, sel::AnyValiditySelection, detector::DetectorIdLike, channel_data::AbstractVector; 
         e_cal_pars_type::Symbol=:rpars, e_cal_pars_cat::Symbol=:ecal,
-        psd_cal_pars_type::Symbol=:ppars, psd_cal_pars_cat::Symbol=:aoe, psd_cut_pars_type::Symbol=:ppars, psd_cut_pars_cat::Symbol=:aoe,
+        psd_pars_type::Symbol=:ppars,
+        aoe_cal_pars_type::Symbol=:ppars, aoe_cal_pars_cat::Symbol=:aoe, aoe_cut_pars_type::Symbol=:ppars, aoe_cut_pars_cat::Symbol=:aoe,
+        lq_cal_pars_type::Symbol=:ppars, lq_cal_pars_cat::Symbol=:lq, lq_cut_pars_type::Symbol=:ppars, lq_cut_pars_cat::Symbol=:lq,
         keep_chdata::Bool=false)
     
     detector = DetectorId(detector)
@@ -22,7 +24,7 @@ function calibrate_ged_channel_data(data::LegendData, sel::AnyValiditySelection,
 
     # get energy and psd calibration functions for the detector
     cal_pf = get_ged_cal_propfunc(data, sel, detector; pars_type=e_cal_pars_type, pars_cat=e_cal_pars_cat)
-    psd_pf = get_ged_psd_propfunc(data, sel, detector; pars_type=psd_cal_pars_type, pars_cat=psd_cal_pars_cat)
+    psd_pf = get_ged_psd_propfunc(data, sel, detector; aoe_pars_type=aoe_cal_pars_type, aoe_pars_cat=aoe_cal_pars_cat, lq_pars_type=lq_cal_pars_type, lq_pars_cat=lq_cal_pars_cat)
 
     # get qc labels
     cut_pf = get_ged_qc_cuts_propfunc(data, sel, detector)
@@ -40,8 +42,10 @@ function calibrate_ged_channel_data(data::LegendData, sel::AnyValiditySelection,
     end
     
     # get postcal psd flags
-    aoecut_pf = get_ged_aoe_cut_propfunc(data, sel, detector; pars_type=psd_cut_pars_type, pars_cat=psd_cut_pars_cat)
-    
+    aoecut_pf = get_ged_aoe_cut_propfunc(data, sel, detector; pars_type=aoe_cut_pars_type, pars_cat=aoe_cut_pars_cat)
+    lqcut_pf = get_ged_lq_cut_propfunc(data, sel, detector; pars_type=lq_cut_pars_type, pars_cat=lq_cut_pars_cat)
+    psdcut_pf = get_ged_psd_classifier_propfunc(data, sel, detector; pars_type=psd_pars_type)
+
     # apply calibrations 
     cal_output = cal_pf.(chdata)
     psd_output = psd_pf.(StructArray(merge(columns(cal_output), columns(chdata))))
@@ -51,23 +55,29 @@ function calibrate_ged_channel_data(data::LegendData, sel::AnyValiditySelection,
     cut_output = cut_pf.(cal_chdata)
 
     # get postcal data
-    postcal_data = aoecut_pf.(cal_chdata)
+    postcal_data = StructArray(merge(columns(aoecut_pf.(cal_chdata)), columns(lqcut_pf.(cal_chdata))))
+    psd_classifier = psdcut_pf.(postcal_data)
+
+    additional_psd_cols = (
+        psd_classifier = psd_classifier,
+    )
 
     # get additional columns 
     chdata_output = chdata_output_pf.(chdata)
 
-    # get cut flags
+    # get qc cut flags
     is_physical = cut_is_physical_pf.(cut_output)
     is_baseline = cut_is_baseline_pf.(cut_output)
     is_physical_trig = cut_is_trig_pf.(cal_chdata) .&& is_physical
+
     
-    additional_cols = (
+    additional_qc_cols = (
         is_physical = is_physical,
         is_baseline = is_baseline,
         is_physical_trig = is_physical_trig,
     )
 
-    return StructVector(merge(columns(chdata_output), columns(cal_output), columns(psd_output), columns(postcal_data), columns(cut_output), additional_cols))
+    return StructVector(merge(columns(chdata_output), columns(cal_output), columns(psd_output), columns(postcal_data), additional_psd_cols, columns(cut_output), additional_qc_cols))
 end
 export calibrate_ged_channel_data
 


### PR DESCRIPTION
This PR includes the `LQ` in the `jlevt` level:
- `LQ` calibration and cut definition, including new classifier per detector
- New `psd_classifier` definition based on a user-defined cut combination
- New global `is_valid_psd` event tag for easier event selection based on valid `psd_classifier` of all triggered channels

**Note**: This PR only works in combination with [PR#93](https://github.com/legend-exp/LegendDataManagement.jl/pull/93) in `LegendDataManagement`