### PR TITLE
Bug FIx `PMT` calibration

### DIFF
--- a/src/calibrate_all.jl
+++ b/src/calibrate_all.jl
@@ -112,7 +112,7 @@ function calibrate_all(data::LegendData, sel::AnyValiditySelection, datastore::A
     spm_events = StructArray(map(_fix_vov, columns(spm_events_novov)))
 
     # PMT:
-    pmt_events = if all(.!haskey.(Ref(ds), pmts_channels))
+    pmt_events = if all(.!haskey.(Ref(ds), string.(pmts_channels)))
         @warn "No PMT data found, skip PMT calibration"
         Vector{NamedTuple{(:timestamp, ), Tuple{Unitful.Time{<:Real}, }}}()
     else


### PR DESCRIPTION
With the current implementation, no `PMT`was written out since the check for available `PMT` channels failed. This PR fixes this by checking the availability of `PMT` channels with `haskey` and the `String` expression of each `ChannelId`