### PR TITLE
New `ft_spm` LAr cut

### DIFF
--- a/src/calibrate_all.jl
+++ b/src/calibrate_all.jl
@@ -159,7 +159,8 @@ function calibrate_all(data::LegendData, sel::AnyValiditySelection, datastore::A
     global_events = StructVector(merge(Base.structdiff(columns(global_events_pre), NamedTuple{keys(aux_events)}), (aux = StructArray(aux_cols),)))
 
     cross_systems_cols = (
-        ged_spm = _build_lar_cut(data, sel, global_events),
+        ged_spm = _build_lar_cut(data, sel, global_events, global_events.geds.t0_start),
+        ft_spm = _build_lar_cut(data, sel, global_events, fill(get_spms_evt_lar_cut_props(data, sel).ft_cut_t0, length(global_events.geds.t0_start))),
         ged_pmt = _build_muon_evt_cut(data, sel, global_events, pmt_events)
     )
 

--- a/src/calibrate_smps.jl
+++ b/src/calibrate_smps.jl
@@ -72,9 +72,7 @@ function _lar_cut(
     return NamedTuple{colnames, Tuple{Bool, eltype(eltype(spm_pe)), Int}}([lar_cut, pe_sum, n_over_thresh])
 end
 
-function _build_lar_cut(data::LegendData, sel::AnyValiditySelection, global_events::AbstractVector{<:NamedTuple}, e_filter::Symbol)
-    geds_t0 = global_events.geds.t0_start
-
+function _build_lar_cut(data::LegendData, sel::AnyValiditySelection, global_events::AbstractVector{<:NamedTuple}, geds_t0::AbstractVector{<:Unitful.Time{<:Real}}, e_filter::Symbol)
     dataprod_larcut = get_spms_evt_lar_cut_props(data, sel)
     dataprod_larcut_filter = dataprod_larcut.energy_types[e_filter]
 
@@ -94,12 +92,12 @@ function _build_lar_cut(data::LegendData, sel::AnyValiditySelection, global_even
     return StructArray(_lar_cut.(Ref(colnames), t_wins, spm_t, spmdc, spm_pe, Ref(pe_ch_threshold), Ref(pe_sum_threshold), Ref(multiplicity_threshold)))
 end
 
-function _build_lar_cut(data::LegendData, sel::AnyValiditySelection, global_events::AbstractVector{<:NamedTuple})
+function _build_lar_cut(data::LegendData, sel::AnyValiditySelection, global_events::AbstractVector{<:NamedTuple}, geds_t0::AbstractVector{<:Unitful.Time{<:Real}})
     dataprod_larcut = get_spms_evt_lar_cut_props(data, sel)
     energy_types = keys(dataprod_larcut.energy_types)
 
     is_valid_lar_propfunc = ljl_propfunc(dataprod_larcut.is_valid_lar)
     
-    lar_cut = StructArray(merge(columns.(_build_lar_cut.(Ref(data), Ref(sel), Ref(global_events), energy_types))...))
+    lar_cut = StructArray(merge(columns.(_build_lar_cut.(Ref(data), Ref(sel), Ref(global_events), Ref(geds_t0), energy_types))...))
     return StructArray(merge((is_valid_lar = is_valid_lar_propfunc.(lar_cut),), columns(lar_cut)))
 end


### PR DESCRIPTION
This PR adds a new `ft_spm` LAr cut based on a fixed `t0` within the trace to study efficiencies based on forced trigger events.