### PR TITLE
Bug Fix `datastore` type

### DIFF
--- a/src/LegendEventAnalysis.jl
+++ b/src/LegendEventAnalysis.jl
@@ -20,6 +20,8 @@ using Unitful: RealOrRealQuantity as RealQuantity
 using LegendDataTypes: fast_flatten
 
 
+const AbstractDataStore = Union{AbstractDict, NamedTuple}
+
 include("flatten_over_channels.jl")
 include("build_global_events.jl")
 include("calibrate_geds.jl")

--- a/src/calibrate_all.jl
+++ b/src/calibrate_all.jl
@@ -7,7 +7,7 @@
 Calibrate all channels in the given datastore, using the metadata
 processing configuration for `data` and `sel`.
 """
-function calibrate_all(data::LegendData, sel::AnyValiditySelection, datastore::AbstractDict, tier::DataTierLike=:jldsp)
+function calibrate_all(data::LegendData, sel::AnyValiditySelection, datastore::AbstractDataStore, tier::DataTierLike=:jldsp)
     ds = datastore
 
     @debug "Calibrating all channels in for `ValiditySelection` $(sel) in `DataTier` $(tier)"


### PR DESCRIPTION
Allow a `NamedTuple` to be used as `datastore` in `calibrate_all` which is the default output of `read_ldata` in the `LegendDataManagementLegendHDF5IOExt`. Then you can do the following
``` julia
l200 = LegendData(:l200)
period = DataPeriod(3)
run = DataRun(0)
cat = DataCategory(:phy)
dsp = read_ldata(l200, DataTier(:jldsp), cat, period, run)
evt = calibrate_all(l200, start_filekey(l200, period, run, cat), dsp)
``` 