### PR TITLE
Add flexible channel key resolution, detector logs in event processor, t0 filtering, and variable PMT DAQ timing offset

### DIFF
--- a/src/calibrate_pmts.jl
+++ b/src/calibrate_pmts.jl
@@ -102,8 +102,12 @@ function _build_muon_evt_cut(data::LegendData, sel::AnyValiditySelection, global
     dataprod_muoncut = get_pmts_evt_muon_cut_props(data, sel)
     
     ged_sum_window = dataprod_muoncut.ged_sum_window
+    
+    # Apply optional tstart offset (for timing correction between HPGe and PMT systems)
+    pmt_tstart_offset = get(dataprod_muoncut, :pmt_tstart_offset, 0.0u"µs")
+    geds_t0_corrected = geds_t0_absolute .+ pmt_tstart_offset
 
-    t_wins = ClosedInterval.(geds_t0_absolute .+ first(ged_sum_window), geds_t0_absolute .+ last(ged_sum_window))
+    t_wins = ClosedInterval.(geds_t0_corrected .+ first(ged_sum_window), geds_t0_corrected .+ last(ged_sum_window))
 
     evtdata_output_pf = get_pmts_evt_evtdata_propfunc(data, sel)
     pmt_events_trig = evtdata_output_pf.(pmt_events[findall(.!pmt_events.is_valid_muon)])


### PR DESCRIPTION
This PR improves the event calibration pipeline with better detector/channel ID compatibility, enhanced t0 filtering for muon veto timing, and a configurable PMT timing offset for fine-tuning coincidence windows.

**Changes**

**Flexible Channel Key Resolution**

Add _get_channel_data helper that tries detector name key first, falls back to channel ID
Add _has_channel_data helper for checking data availability under either key format
Update HPGe, SiPM, PMT and AUX channel access to use new helpers
Fix SiPM progress bar to use correct array length (spms_channels instead of geds_channels)
Ensures compatibility with both old (channel ID) and new (detector name) jldsp file formats

**t0 Filtering for Muon Veto**

Add configurable ged_t0_valid_window parameter (e.g., [40, 60] µs)
New min_t0_filtered function filters t0 values outside the valid physics window
Properly handles NaN values using isnan(ustrip(x)) for Unitful compatibility
Falls back to NaN if no valid t0 values remain
Ensures muon veto coincidence timing uses only valid t0 values from calibrated detectors

**Calibration Quality Checks**

Add _check_calibration_quality function identifying detectors with missing calibrations:
HPGe: Detectors with all-NaN e_cusp_ctc_cal (includes usability status)
SiPM: Detectors with all-NaN trig_max_cal
PMT: Detectors with all-NaN e_fc or missing pmt_caldata
Log warnings for each category of missing calibrations
Return calibration_issues as third return value from calibrate_all

**PMT Timing Offset**

Add support for pmt_tstart_offset config parameter in muon veto coincidence matching
Apply offset to geds_t0_absolute before computing coincidence windows
Allows fine-tuning of muon veto timing window alignment without modifying base ged_sum_window values

