### PR TITLE
Refactor event building to use DetectorId instead of ChannelId

### DIFF
--- a/src/build_global_events.jl
+++ b/src/build_global_events.jl
@@ -18,7 +18,7 @@ The `tstart` column contains the start time of each event, the `detector`,
 detector-id, per-detector event numbers and per-detector
 timestamps that have been associated with each respective events.
 
-Per-detector events are accociated with the same global event if their
+Per-detector events are associated with the same global event if their
 timestamps fall within a time windows of length `ts_window`.
 """
 function build_global_event_map(data::StructVector; ts_window::Number = 25u"μs")
@@ -109,7 +109,7 @@ export apply_event_map
 
 Build global events from a dictionary of per-detector events
 
-Per-detector events are accociated with the same global event if their
+Per-detector events are associated with the same global event if their
 timestamps fall within a time windows of length `ts_window`.
 
 `data` must a dictionary of in-memory or on-disk table-like objects, keyed by

--- a/src/build_global_events.jl
+++ b/src/build_global_events.jl
@@ -6,59 +6,59 @@
 
 Build a map of global events based on `local_events`.
 
-`data` must contain columns `channel`, `chevtno` and `timestamp`. It will
-typically be the result of [`flatten_over_channels`](@ref).
+`data` must contain columns `detector`, `detevtno` and `timestamp`. It will
+typically be the result of [`flatten_over_detectors`](@ref).
 
-Returns a `StructArray` that contains the columns `start`, `channels`,
-`localevents` and `timestamps`, sorted by `start` globally and along
-`timestamps` in each row.
+Returns a `StructArray` that contains the columns `tstart`, `detector`,
+`detevtno` and `timestamp`, sorted by `tstart` globally and along
+`timestamp` in each row.
 
-The `start` column contains the start time of each event, the `channels`,
-`chevts` and `timestamps` columns are vectors of vectors that contain the
-channel-id, per-channel event numbers and per-channel
+The `tstart` column contains the start time of each event, the `detector`,
+`detevtno` and `timestamp` columns are vectors of vectors that contain the
+detector-id, per-detector event numbers and per-detector
 timestamps that have been associated with each respective events.
 
-Per-channel events are accociated with the same global event if their
+Per-detector events are accociated with the same global event if their
 timestamps fall within a time windows of length `ts_window`.
 """
 function build_global_event_map(data::StructVector; ts_window::Number = 25u"μs")
     tssortidxs = sortperm(data.timestamp)
-    local_channel = data.channel[tssortidxs]
-    local_chevtno = data.chevtno[tssortidxs]
+    local_detector = data.detector[tssortidxs]
+    local_detevtno = data.detevtno[tssortidxs]
     local_timestamp = data.timestamp[tssortidxs]
 
     this_evt_start = zero(eltype(data.timestamp))
     this_evt_dataidxs = Vector{Int}()
-    this_evt_channels = Vector{eltype(data.channel)}()
-    this_evt_chevtnos = Vector{Int}()
+    this_evt_detectors = Vector{eltype(data.detector)}()
+    this_evt_detevtnos = Vector{Int}()
     this_evt_timestamps = Vector{eltype(data.timestamp)}()
 
     all_start = Vector{eltype(data.timestamp)}()
     all_dataidxs = VectorOfVectors{Int}()
-    all_channels = VectorOfVectors{eltype(data.channel)}()
-    all_chevtnos = VectorOfVectors{Int}()
+    all_detectors = VectorOfVectors{eltype(data.detector)}()
+    all_detevtnos = VectorOfVectors{Int}()
     all_timestamps = VectorOfVectors{eltype(data.timestamp)}()
 
     function _flush_evt(i)
-        if !isempty(this_evt_channels)
+        if !isempty(this_evt_detectors)
             push!(all_start, this_evt_start)
             push!(all_dataidxs, this_evt_dataidxs); empty!(this_evt_dataidxs)
-            push!(all_chevtnos, this_evt_chevtnos); empty!(this_evt_chevtnos)
-            push!(all_channels, this_evt_channels); empty!(this_evt_channels)
+            push!(all_detevtnos, this_evt_detevtnos); empty!(this_evt_detevtnos)
+            push!(all_detectors, this_evt_detectors); empty!(this_evt_detectors)
             push!(all_timestamps, this_evt_timestamps); empty!(this_evt_timestamps)
         end
     end
 
     first_entry = true
     for i in eachindex(local_timestamp)
-        ch, chevtno, ts = local_channel[i], local_chevtno[i], local_timestamp[i]
+        det, detevtno, ts = local_detector[i], local_detevtno[i], local_timestamp[i]
         if first_entry || ts - this_evt_start > ts_window
             _flush_evt(i)
             this_evt_start = ts
         end
         push!(this_evt_dataidxs, tssortidxs[i])
-        push!(this_evt_channels, ch)
-        push!(this_evt_chevtnos, chevtno)
+        push!(this_evt_detectors, det)
+        push!(this_evt_detevtnos, detevtno)
         push!(this_evt_timestamps, ts)
 
         first_entry = false
@@ -68,7 +68,7 @@ function build_global_event_map(data::StructVector; ts_window::Number = 25u"μs"
 
     return StructVector(
         tstart = all_start, dataidx = all_dataidxs,
-        chevtno = all_chevtnos, channel = all_channels, timestamp = all_timestamps
+        detevtno = all_detevtnos, detector = all_detectors, timestamp = all_timestamps
     )
 end
 export build_global_event_map
@@ -79,7 +79,7 @@ export build_global_event_map
 
 Apply the event map `evtmap` to the data `data`.
 
-`data` will typically be the result of [`flatten_over_channels`](@ref) and
+`data` will typically be the result of [`flatten_over_detectors`](@ref) and
 `evtmap` the result of [`build_global_event_map`](@ref).
 """
 function apply_event_map(data::StructVector, evtmap::StructVector)
@@ -102,28 +102,28 @@ export apply_event_map
 
 """
     function build_global_events(
-        data::AbstractDict{<:ChannelIdLike},
-        channels::AbstractVector{<:ChannelIdLike} = collect(keys(data));
+        data::AbstractDict{<:DetectorIdLike},
+        detectors::AbstractVector{<:DetectorIdLike} = collect(keys(data));
         ts_window::Number = 25u"μs"
     )
 
-Build global events from a dictionary of per-channel events
+Build global events from a dictionary of per-detector events
 
-Per-channel events are accociated with the same global event if their
+Per-detector events are accociated with the same global event if their
 timestamps fall within a time windows of length `ts_window`.
 
 `data` must a dictionary of in-memory or on-disk table-like objects, keyed by
-channel-IDs. It may, e.g. be a `Dict` with values that are
+detector-IDs. It may, e.g. be a `Dict` with values that are
 `StructArrays.StructVector`, `TypedTables.Table` or similar, but may also be a
 `LegendHDF5IO.LHDataStore`. Note that on-disk data will be read into memory
 as a whole.
 """
 function build_global_events(
-    data::AbstractDict{<:ChannelIdLike},
-    channels::AbstractVector{<:ChannelIdLike} = collect(keys(data));
+    data::AbstractDict{<:DetectorIdLike},
+    detectors::AbstractVector{<:DetectorIdLike} = collect(keys(data));
     ts_window::Number = 25u"μs"
 )
-    flat_data = flatten_over_channels(data, channels).result
+    flat_data = flatten_over_detectors(data, detectors).result
     evtmap = build_global_event_map(flat_data; ts_window = ts_window)
     return apply_event_map(flat_data, evtmap)
 end

--- a/src/calibrate_aux.jl
+++ b/src/calibrate_aux.jl
@@ -1,28 +1,28 @@
 # This file is a part of LegendEventAnalysis.jl, licensed under the MIT License (MIT).
 
 """
-    calibrate_aux_channel_data(data::LegendData, sel::ValiditySelection, detector::DetectorId, channel_data::AbstractVector)
+    calibrate_aux_detector_data(data::LegendData, sel::ValiditySelection, detector::DetectorId, detector_data::AbstractVector)
 
-Apply the calibration specified by `data` and `sel` for aux channel referred to
-by the `detector` ID to the single-channel `channel_data` for that detector.
+Apply the calibration specified by `data` and `sel` for aux detector referred to
+by the `detector` ID to the single-detector `detector_data` for that detector.
 
 Also calculates the configured cut/flag values.
 """
-function calibrate_aux_channel_data(data::LegendData, sel::AnyValiditySelection, detector::DetectorId, channel_data::AbstractVector)
-    chdata = channel_data[:]
+function calibrate_aux_detector_data(data::LegendData, sel::AnyValiditySelection, detector::DetectorId, detector_data::AbstractVector)
+    detdata = detector_data[:]
 
     # get calibration function for the detector
     auxcal_pf = get_aux_cal_propfunc(data, sel, detector)
 
     # get additional cols to be parsed into the event tier
-    chdata_output_pf = get_aux_evt_chdata_propfunc(data, sel, detector)
+    detdata_output_pf = get_aux_evt_detdata_propfunc(data, sel, detector)
 
     # get additional columns
-    chdata_output = chdata_output_pf.(chdata)
+    detdata_output = detdata_output_pf.(detdata)
 
     # apply calibrations
-    cal_output = auxcal_pf.(chdata)
+    cal_output = auxcal_pf.(detdata)
 
-    return StructVector(merge(columns(chdata_output), columns(cal_output)))
+    return StructVector(merge(columns(detdata_output), columns(cal_output)))
 end
-export calibrate_aux_channel_data
+export calibrate_aux_detector_data

--- a/src/calibrate_geds.jl
+++ b/src/calibrate_geds.jl
@@ -1,26 +1,26 @@
 # This file is a part of LegendEventAnalysis.jl, licensed under the MIT License (MIT).
 
 """
-    calibrate_ged_channel_data(data::LegendData, sel::AnyValiditySelection, detector::DetectorId, channel_data::AbstractVector; 
+    calibrate_ged_detector_data(data::LegendData, sel::AnyValiditySelection, detector::DetectorId, detector_data::AbstractVector; 
         psd_cal_pars_type::Symbol=:ppars, psd_cal_pars_cat::Symbol=:aoe, psd_cut_pars_type::Symbol=:ppars, psd_cut_pars_cat::Symbol=:aoe,
-        keep_chdata::Bool=false)
+        keep_detdata::Bool=false)
 
 Apply the calibration specified by `data` and `sel` for the given HPGe
-`detector` to the single-channel `channel_data` for that detector.
+`detector` to the single-detector `detector_data` for that detector.
 
 Also calculates the configured cut/flag values.
 """
-function calibrate_ged_channel_data(data::LegendData, sel::AnyValiditySelection, detector::DetectorIdLike, channel_data::AbstractVector; 
+function calibrate_ged_detector_data(data::LegendData, sel::AnyValiditySelection, detector::DetectorIdLike, detector_data::AbstractVector; 
         e_cal_pars_type::Symbol=:rpars, e_cal_pars_cat::Symbol=:ecal,
         psd_pars_type::Symbol=:ppars,
         aoe_cal_pars_type::Symbol=:ppars, aoe_cal_pars_cat::Symbol=:aoe, aoe_cut_pars_type::Symbol=:ppars, aoe_cut_pars_cat::Symbol=:aoe,
         lq_cal_pars_type::Symbol=:ppars, lq_cal_pars_cat::Symbol=:lq, lq_cut_pars_type::Symbol=:ppars, lq_cut_pars_cat::Symbol=:lq,
-        keep_chdata::Bool=false)
+        keep_detdata::Bool=false)
     
     detector = DetectorId(detector)
 
-    # get all chdata
-    chdata = channel_data[:]
+    # get all detdata
+    detdata = detector_data[:]
 
     # get energy and psd calibration functions for the detector
     cal_pf = get_ged_cal_propfunc(data, sel, detector; pars_type=e_cal_pars_type, pars_cat=e_cal_pars_cat)
@@ -35,10 +35,10 @@ function calibrate_ged_channel_data(data::LegendData, sel::AnyValiditySelection,
     cut_is_trig_pf = get_ged_qc_is_trig_propfunc(data, sel, detector)
     
     # get additional cols to be parsed into the event tier
-    chdata_output_pf = if keep_chdata
-        PropSelFunction{propertynames(chdata)}()
+    detdata_output_pf = if keep_detdata
+        PropSelFunction{propertynames(detdata)}()
     else
-        get_ged_evt_chdata_propfunc(data, sel)
+        get_ged_evt_detdata_propfunc(data, sel)
     end
     
     # get postcal psd flags
@@ -47,15 +47,15 @@ function calibrate_ged_channel_data(data::LegendData, sel::AnyValiditySelection,
     psdcut_pf = get_ged_psd_classifier_propfunc(data, sel, detector; pars_type=psd_pars_type)
 
     # apply calibrations 
-    cal_output = cal_pf.(chdata)
-    psd_output = psd_pf.(StructArray(merge(columns(cal_output), columns(chdata))))
-    cal_chdata = StructArray(merge(columns(cal_output), columns(psd_output), columns(chdata)))
+    cal_output = cal_pf.(detdata)
+    psd_output = psd_pf.(StructArray(merge(columns(cal_output), columns(detdata))))
+    cal_detdata = StructArray(merge(columns(cal_output), columns(psd_output), columns(detdata)))
 
     # get cut labels
-    cut_output = cut_pf.(cal_chdata)
+    cut_output = cut_pf.(cal_detdata)
 
     # get postcal data
-    postcal_data = StructArray(merge(columns(aoecut_pf.(cal_chdata)), columns(lqcut_pf.(cal_chdata))))
+    postcal_data = StructArray(merge(columns(aoecut_pf.(cal_detdata)), columns(lqcut_pf.(cal_detdata))))
     psd_classifier = psdcut_pf.(postcal_data)
 
     additional_psd_cols = (
@@ -63,12 +63,12 @@ function calibrate_ged_channel_data(data::LegendData, sel::AnyValiditySelection,
     )
 
     # get additional columns 
-    chdata_output = chdata_output_pf.(chdata)
+    detdata_output = detdata_output_pf.(detdata)
 
     # get qc cut flags
     is_physical = cut_is_physical_pf.(cut_output)
     is_baseline = cut_is_baseline_pf.(cut_output)
-    is_physical_trig = cut_is_trig_pf.(cal_chdata) .&& is_physical
+    is_physical_trig = cut_is_trig_pf.(cal_detdata) .&& is_physical
 
     
     additional_qc_cols = (
@@ -77,9 +77,9 @@ function calibrate_ged_channel_data(data::LegendData, sel::AnyValiditySelection,
         is_physical_trig = is_physical_trig,
     )
 
-    return StructVector(merge(columns(chdata_output), columns(cal_output), columns(psd_output), columns(postcal_data), additional_psd_cols, columns(cut_output), additional_qc_cols))
+    return StructVector(merge(columns(detdata_output), columns(cal_output), columns(psd_output), columns(postcal_data), additional_psd_cols, columns(cut_output), additional_qc_cols))
 end
-export calibrate_ged_channel_data
+export calibrate_ged_detector_data
 
-calibrate_ged_channel_data(data::LegendData, sel::AnyValiditySelection, detector::DetectorIdLike, tier::DataTierLike; kwargs...) =
-    calibrate_ged_channel_data(data, sel, detector, read_ldata(data, tier, sel, detector), kwargs...)
+calibrate_ged_detector_data(data::LegendData, sel::AnyValiditySelection, detector::DetectorIdLike, tier::DataTierLike; kwargs...) =
+    calibrate_ged_detector_data(data, sel, detector, read_ldata(data, tier, sel, detector), kwargs...)

--- a/src/calibrate_pmts.jl
+++ b/src/calibrate_pmts.jl
@@ -1,39 +1,39 @@
 # This file is a part of LegendEventAnalysis.jl, licensed under the MIT License (MIT).
 
 """
-    calibrate_pmt_channel_data(data::LegendData, sel::ValiditySelection, detector::DetectorId, channel_data::AbstractVector)
+    calibrate_pmt_detector_data(data::LegendData, sel::ValiditySelection, detector::DetectorId, detector_data::AbstractVector)
 
 Apply the calibration specified by `data` and `sel` for the given PMT
-`detector` to the single-channel `channel_data` for that detector.
+`detector` to the single-detector `detector_data` for that detector.
 
 Also calculates the configured cut/flag values.
 """
-function calibrate_pmt_channel_data(data::LegendData, sel::AnyValiditySelection, detector::DetectorId, channel_data::AbstractVector; 
+function calibrate_pmt_detector_data(data::LegendData, sel::AnyValiditySelection, detector::DetectorId, detector_data::AbstractVector; 
     e_cal_pars_type::Symbol=:rpars, e_cal_pars_cat::Symbol=:pmtcal, 
-    keep_chdata::Bool=false)
-    chdata = channel_data[:]
+    keep_detdata::Bool=false)
+    detdata = detector_data[:]
 
     pmtcal_pf = get_pmt_cal_propfunc(data, sel, detector; pars_type=e_cal_pars_type, pars_cat=e_cal_pars_cat)
     cut_is_physical_trig = get_pmt_is_physical_trig_propfunc(data, sel, detector; pars_type=e_cal_pars_type)
 
     # get additional cols to be parsed into the event tier
-    chdata_output_pf = if keep_chdata
-        PropSelFunction{propertynames(chdata)}()
+    detdata_output_pf = if keep_detdata
+        PropSelFunction{propertynames(detdata)}()
     else
-        get_pmts_evt_chdata_propfunc(data, sel)
+        get_pmts_evt_detdata_propfunc(data, sel)
     end
 
-    cal_output = pmtcal_pf.(chdata)
+    cal_output = pmtcal_pf.(detdata)
 
-    cal_chdata = StructArray(merge(columns(cal_output), columns(chdata)))
+    cal_detdata = StructArray(merge(columns(cal_output), columns(detdata)))
 
-    chdata_output = chdata_output_pf.(chdata)
+    detdata_output = detdata_output_pf.(detdata)
 
-    is_physical_trig = cut_is_physical_trig.(cal_chdata)
+    is_physical_trig = cut_is_physical_trig.(cal_detdata)
     
-    return StructVector(merge(columns(cal_output), columns(chdata_output), columns(is_physical_trig)))
+    return StructVector(merge(columns(cal_output), columns(detdata_output), columns(is_physical_trig)))
 end
-export calibrate_pmt_channel_data
+export calibrate_pmt_detector_data
 
 function _muon_cut(
     colnames::Tuple{Symbol, Symbol, Symbol},

--- a/src/flatten_over_channels.jl
+++ b/src/flatten_over_channels.jl
@@ -1,43 +1,43 @@
 # This file is a part of LegendEventAnalysis.jl, licensed under the MIT License (MIT).
 
 
-function _data_with_channel(all_ch_data::AbstractDict{<:ChannelIdLike}, ch::ChannelIdLike)
-    data = all_ch_data[ch][:]
-    ch_cols = (channel = fill(Int(ch), length(data)), chevtno = collect(eachindex(data)))
-    StructVector(merge(ch_cols, columns(data)))
+function _data_with_detector(all_det_data::AbstractDict{<:DetectorIdLike}, det::DetectorIdLike)
+    data = all_det_data[det][:]
+    det_cols = (detector = fill(DetectorId(det), length(data)), detevtno = collect(eachindex(data)))
+    StructVector(merge(det_cols, columns(data)))
 end
 
 """
-    function flatten_over_channels(
-        data::AbstractDict{<:ChannelIdLike},
-        channels::AbstractVector{<:ChannelIdLike} = collect(keys(data))
+    function flatten_over_detectors(
+        data::AbstractDict{<:DetectorIdLike},
+        detectors::AbstractVector{<:DetectorIdLike} = collect(keys(data))
     )
 
-Flatten per-channel data `data` to a single `StructArrays.StructVector` by
-concatenating its table-like values and adding the columns a `channel` and
-`chevtno`.
+Flatten per-detector data `data` to a single `StructArrays.StructVector` by
+concatenating its table-like values and adding the columns `detector` and
+`detevtno`.
 
 `data` must a dictionary of in-memory or on-disk table-like objects, keyed by
-channel-IDs. It may, e.g. be a `Dict` with values that are
+detector-IDs. It may, e.g. be a `Dict` with values that are
 `StructArrays.StructVector`, `TypedTables.Table` or similar, but may also be a
 `LegendHDF5IO.LHDataStore`. Note that on-disk data will be read into memory
 as a whole.
 
-Returns a `NamedTuple{(:result, :per_channel)}`: `result` is the flattened
-data and `per_channel` is a channel-indexed dictionary of views into `result`.
+Returns a `NamedTuple{(:result, :per_detector)}`: `result` is the flattened
+data and `per_detector` is a detector-indexed dictionary of views into `result`.
 """
-function flatten_over_channels(
-    data::AbstractDict{<:ChannelIdLike},
-    channels::AbstractVector{<:ChannelIdLike} = collect(keys(data))
+function flatten_over_detectors(
+    data::AbstractDict{<:DetectorIdLike},
+    detectors::AbstractVector{<:DetectorIdLike} = collect(keys(data))
 )
-    flat_result = _data_with_channel(data, ChannelId(first(channels)))
+    flat_result = _data_with_detector(data, DetectorId(first(detectors)))
     view_ranges = [firstindex(flat_result):lastindex(flat_result)]
-    @showprogress desc="Flattening data over channels" for ch in channels[begin+1:end]
-        chunk = _data_with_channel(data, ChannelId(ch))
+    @showprogress desc="Flattening data over detectors" for det in detectors[begin+1:end]
+        chunk = _data_with_detector(data, DetectorId(det))
         push!(view_ranges, lastindex(flat_result)+1:lastindex(flat_result)+length(chunk))
         append!(flat_result, chunk)
     end
-    dict_result = Dict(broadcast((ch, r) -> ChannelId(ch) => view(flat_result, r), channels, view_ranges))
-    return (result = flat_result, per_channel = dict_result)
+    dict_result = Dict(broadcast((det, r) -> DetectorId(det) => view(flat_result, r), detectors, view_ranges))
+    return (result = flat_result, per_detector = dict_result)
 end
-export flatten_over_channels
+export flatten_over_detectors


### PR DESCRIPTION
Aligns event building with new DSP logic where data is keyed by detector ID.

Changes:
- Rename flatten_over_channels to flatten_over_detectors
- Replace channel/chevtno columns with detector/detevtno
- Store detector as DetectorId type instead of Int
- Update build_global_events to use DetectorIdLike signatures
- Refactor calibrate_all.jl to use detector-based access
- Remove unnecessary only.() wrapper from max_e_det