### PR TITLE
Implementation of classical QC and refactor of is_valid_qc logic

### DIFF
--- a/src/calibrate_all.jl
+++ b/src/calibrate_all.jl
@@ -53,8 +53,6 @@ function calibrate_all(data::LegendData, sel::AnyValiditySelection, datastore::A
     trig_e_cusp_ctc_cal = _fix_vov(getindex.(ged_events_pre.e_cusp_ctc_cal, trig_e_det))
     trig_e_535_cal      = _fix_vov(getindex.(ged_events_pre.e_535_cal, trig_e_det))
     trig_t0 = _fix_vov(getindex.(ged_events_pre.t0, trig_e_det))
-    n_trig = length.(trig_e_det)
-    n_expected_baseline = length.(ged_events_pre.is_baseline) .- length.(trig_e_det)
     
     maximum_with_init(A) = maximum(A, init=zero(eltype((A))))
 
@@ -69,7 +67,7 @@ function calibrate_all(data::LegendData, sel::AnyValiditySelection, datastore::A
     ged_additional_cols = (
         t0_start = min_t0.(trig_t0),
         trig_t0 = trig_t0,
-        multiplicity = n_trig,
+        multiplicity = sum(ged_events_pre.is_physical_trig),
         max_e_det_idxs = max_e_det,
         max_e_det = getindex.(ged_events_pre.detector, max_e_det),
         max_e_trap_cal = maximum_with_init.(trig_e_trap_max_cal),
@@ -84,7 +82,7 @@ function calibrate_all(data::LegendData, sel::AnyValiditySelection, datastore::A
         trig_e_trap_ctc_cal = trig_e_trap_ctc_cal,
         trig_e_cusp_ctc_cal = trig_e_cusp_ctc_cal,
         trig_e_535_cal = trig_e_535_cal,
-        is_valid_qc = count.(ged_events_pre.is_baseline) .== n_expected_baseline,
+        is_valid_qc = all(ged_events_pre.is_baseline .|| ged_events_pre.is_physical),
         is_valid_trig = is_valid_trig.(getindex.(ged_events_pre.detector, trig_e_det), Ref(hitgeds_detectors)),
         is_valid_hit = is_valid_hit,
         is_valid_psd = all.(getindex.(ged_events_pre.psd_classifier, trig_e_det)),

--- a/src/calibrate_all.jl
+++ b/src/calibrate_all.jl
@@ -67,7 +67,7 @@ function calibrate_all(data::LegendData, sel::AnyValiditySelection, datastore::A
     ged_additional_cols = (
         t0_start = min_t0.(trig_t0),
         trig_t0 = trig_t0,
-        multiplicity = sum(ged_events_pre.is_physical_trig),
+        multiplicity = n_trig = length.(trig_e_det),
         max_e_det_idxs = max_e_det,
         max_e_det = getindex.(ged_events_pre.detector, max_e_det),
         max_e_trap_cal = maximum_with_init.(trig_e_trap_max_cal),
@@ -82,7 +82,7 @@ function calibrate_all(data::LegendData, sel::AnyValiditySelection, datastore::A
         trig_e_trap_ctc_cal = trig_e_trap_ctc_cal,
         trig_e_cusp_ctc_cal = trig_e_cusp_ctc_cal,
         trig_e_535_cal = trig_e_535_cal,
-        is_valid_qc = all(ged_events_pre.is_baseline .|| ged_events_pre.is_physical),
+        is_valid_qc = all.(map((bl, ph) -> bl .| ph, ged_events_pre.is_baseline, ged_events_pre.is_physical)),
         is_valid_trig = is_valid_trig.(getindex.(ged_events_pre.detector, trig_e_det), Ref(hitgeds_detectors)),
         is_valid_hit = is_valid_hit,
         is_valid_psd = all.(getindex.(ged_events_pre.psd_classifier, trig_e_det)),

--- a/src/calibrate_geds.jl
+++ b/src/calibrate_geds.jl
@@ -7,10 +7,13 @@
 
 Apply the calibration specified by `data` and `sel` for the given HPGe
 `detector` to the single-detector `detector_data` for that detector.
+With the kwargs quality_cuts the type of quality cut can be chosen(default :classical).
 
 Also calculates the configured cut/flag values.
+
 """
 function calibrate_ged_detector_data(data::LegendData, sel::AnyValiditySelection, detector::DetectorIdLike, detector_data::AbstractVector; 
+        quality_cuts::Symbol=:classical,
         e_cal_pars_type::Symbol=:rpars, e_cal_pars_cat::Symbol=:ecal,
         psd_pars_type::Symbol=:ppars,
         aoe_cal_pars_type::Symbol=:ppars, aoe_cal_pars_cat::Symbol=:aoe, aoe_cut_pars_type::Symbol=:ppars, aoe_cut_pars_cat::Symbol=:aoe,
@@ -30,9 +33,16 @@ function calibrate_ged_detector_data(data::LegendData, sel::AnyValiditySelection
     cut_pf = get_ged_qc_cuts_propfunc(data, sel, detector)
     
     # get qc cut functions
-    cut_is_physical_pf = get_ged_qc_is_physical_propfunc(data, sel, detector)
-    cut_is_baseline_pf = get_ged_qc_is_baseline_propfunc(data, sel, detector)
     cut_is_trig_pf = get_ged_qc_is_trig_propfunc(data, sel, detector)
+    if quality_cuts == :classical
+        cut_is_physical_pf = get_ged_qc_is_physical_classical_propfunc(data, sel, detector)
+        cut_is_baseline_pf = get_ged_qc_is_baseline_classical_propfunc(data, sel, detector)
+    elseif quality_cuts == :ml
+        cut_is_physical_pf = get_ged_qc_is_physical_ml_propfunc(data, sel, detector)
+        cut_is_baseline_pf = get_ged_qc_is_baseline_ml_propfunc(data, sel, detector)
+    else
+        throw(ArgumentError("Invalid value for `quality_cuts`: $quality_cuts. Valid options are `:classical` and `:ml`."))
+    end
     
     # get additional cols to be parsed into the event tier
     detdata_output_pf = if keep_detdata


### PR DESCRIPTION
This PR adds the option to use classical QC in the event building.
Currently, the user can choose via a keyword argument in the metadata whether to use the ML model or the classical QC for generating the `is_valid_qc` flag.

This PR also refactors the logic of the `is_valid_qc` flag. Previously, the check ensured that the number of baselines minus physical events matched the expected number of baseline events. Since for the classical QC, these labels are no longer mutually exclusive, this logic has been updated. An event now passes `is_valid_qc` if all individual channels are classified as either physical or baseline.