### PR TITLE
revise qc logic

### DIFF
--- a/src/calibrate_all.jl
+++ b/src/calibrate_all.jl
@@ -54,7 +54,6 @@ function calibrate_all(data::LegendData, sel::AnyValiditySelection, datastore::A
     trig_e_535_cal      = _fix_vov(getindex.(ged_events_pre.e_535_cal, trig_e_det))
     trig_t0 = _fix_vov(getindex.(ged_events_pre.t0, trig_e_det))
     n_trig = length.(trig_e_det)
-    n_expected_baseline = length.(ged_events_pre.is_baseline) .- length.(trig_e_det)
     
     maximum_with_init(A) = maximum(A, init=zero(eltype((A))))
 
@@ -84,7 +83,7 @@ function calibrate_all(data::LegendData, sel::AnyValiditySelection, datastore::A
         trig_e_trap_ctc_cal = trig_e_trap_ctc_cal,
         trig_e_cusp_ctc_cal = trig_e_cusp_ctc_cal,
         trig_e_535_cal = trig_e_535_cal,
-        is_valid_qc = count.(ged_events_pre.is_baseline) .== n_expected_baseline,
+        is_valid_qc = all.(map((bl, ph) -> bl .| ph, ged_events_pre.is_baseline, ged_events_pre.is_physical)),
         is_valid_trig = is_valid_trig.(getindex.(ged_events_pre.detector, trig_e_det), Ref(hitgeds_detectors)),
         is_valid_hit = is_valid_hit,
         is_valid_psd = all.(getindex.(ged_events_pre.psd_classifier, trig_e_det)),


### PR DESCRIPTION
This PR refactors the logic of the is_valid_qc flag. Previously, the check ensured that the number of baselines minus physical events matched the expected number of baseline events. Since for the classical QC, these labels are not mutually exclusive, this logic needs to be updated. An event now passes is_valid_qc if all individual channels are classified as either physical or baseline.