### PR TITLE
Fix  ClosedInterval in calibrate PMTs

### DIFF
--- a/src/calibrate_pmts.jl
+++ b/src/calibrate_pmts.jl
@@ -77,7 +77,7 @@ function _muon_evt_cut(
     t_win::AbstractInterval, pmt_tstart::AbstractVector{<:Number},
     pmt_events_trig::AbstractVector{<:NamedTuple}, empty_evt::NamedTuple
 )   
-    muon_cut_idx = findall(pmt_tstart .∈ t_win)
+    muon_cut_idx = findall(in.(pmt_tstart, Ref(t_win)))
     muon_cut = Bool(length(muon_cut_idx) > 0)
 
     trig_evt::typeof(first(pmt_events_trig)) = if muon_cut

--- a/src/calibrate_pmts.jl
+++ b/src/calibrate_pmts.jl
@@ -77,7 +77,7 @@ function _muon_evt_cut(
     t_win::AbstractInterval, pmt_tstart::AbstractVector{<:Number},
     pmt_events_trig::AbstractVector{<:NamedTuple}, empty_evt::NamedTuple
 )   
-    muon_cut_idx = findall(in.(pmt_tstart, Ref(t_win)))
+    muon_cut_idx = findall(in(t_win), pmt_tstart)
     muon_cut = Bool(length(muon_cut_idx) > 0)
 
     trig_evt::typeof(first(pmt_events_trig)) = if muon_cut


### PR DESCRIPTION
Replace pmt_tstart .∈ t_win with in.(pmt_tstart, Ref(t_win)) in _muon_evt_cut. The broadcast ∈ operator does not work correctly with ClosedInterval for element-wise membership testing — in.() with Ref is the correct broadcasting pattern.

### Reproducer

```julia
using IntervalSets, Unitful  # v0.7.13, v1.28.0

pmt_tstart = [2.0, 3.5, 6.0, 4.0] * u"µs"
t_win = ClosedInterval(1.0u"µs", 5.0u"µs")

# OLD — fails with MethodError: no method matching iterate(::ClosedInterval{...})
pmt_tstart .∈ t_win

# NEW — correctly broadcasts membership test
in.(pmt_tstart, Ref(t_win))  # → [true, true, false, true]
```

`.∈` expands to `broadcast(∈, pmt_tstart, t_win)`, which tries to iterate over the `ClosedInterval`. `Ref(t_win)` wraps it as a 0-dimensional container so broadcast treats it as a scalar.