### PR TITLE
Handle duplicate aux entries  (pulser) in cross-system event building

### DIFF
--- a/src/calibrate_all.jl
+++ b/src/calibrate_all.jl
@@ -155,7 +155,8 @@ function calibrate_all(data::LegendData, sel::AnyValiditySelection, datastore::A
     ), aux_events)
 
     global_events_pre = build_cross_system_events(system_events)
-    aux_cols = NamedTuple{keys(aux_events)}([StructVector(map(Broadcast.BroadcastFunction(only), columns(getproperty(global_events_pre, k)))) for k in keys(aux_events)])
+    # Aux channels may have duplicate entries per event from cross-system matching — take first
+    aux_cols = NamedTuple{keys(aux_events)}([StructVector(map(Broadcast.BroadcastFunction(first), columns(getproperty(global_events_pre, k)))) for k in keys(aux_events)])
     global_events = StructVector(merge(Base.structdiff(columns(global_events_pre), NamedTuple{keys(aux_events)}), (aux = StructArray(aux_cols),)))
 
     cross_systems_cols = (


### PR DESCRIPTION
**Description:**
build_cross_system_events groups per-detector events into global events using a 25µs timestamp window. Aux detectors (e.g. pulser) are expected to have exactly one entry per global event, extracted via only(). However, occasional retriggers can place two pulser entries within the same window, causing only() to throw ArgumentError("Collection has multiple elements").

Replace only() with a tolerant wrapper that logs a @warn and takes first() when duplicates occur. This is safe because pulser values within the same 25µs window are effectively identical.

This affects only some files, for example: l200-p18-r005-phy-20251205T140915Z (ErrorException("Error processing l200-p18-r005-phy-20251205T140915Z: ArgumentError("Collection has multiple elements, must contain exactly 1 element")")). 

We can also lower the coincidence window for the pulser (what do you think?)