### PR TITLE
calibrate_all: accept a read_ldata NamedTuple datastore

### DIFF
--- a/src/calibrate_all.jl
+++ b/src/calibrate_all.jl
@@ -2,12 +2,30 @@
 
 
 """
-    calibrate_all(data::LegendData, sel::ValiditySelection, datastore::AbstractDict)
+    calibrate_all(data::LegendData, sel::ValiditySelection, datastore)
 
 Calibrate all detectors in the given datastore, using the metadata
-processing configuration for `data` and `sel`.
+processing configuration for `data` and `sel`. `datastore` may be an
+`AbstractDataStore` (e.g. an open LH5 file) or a `NamedTuple` as returned
+by `read_ldata`.
 """
-function calibrate_all(data::LegendData, sel::AnyValiditySelection, datastore::AbstractDataStore, tier::DataTierLike=:jldsp)
+function calibrate_all end
+export calibrate_all
+
+# make a read_ldata NamedTuple indexable like an LH5 datastore (ds[name, tier]);
+# eager Dict{String,Any} erases the huge per-run NamedTuple type (avoids LLVM blow-up)
+struct _NTDataStore
+    d::Dict{String,Any}
+end
+Base.getindex(s::_NTDataStore, name::AbstractString, ::Any) = s.d[String(name)]
+Base.haskey(s::_NTDataStore, name::AbstractString) = haskey(s.d, String(name))
+
+function calibrate_all(data::LegendData, sel::AnyValiditySelection, datastore::NamedTuple, tier::DataTierLike=:jldsp)
+    ds = _NTDataStore(Dict{String,Any}(string(k) => getproperty(datastore, k) for k in propertynames(datastore)))
+    return calibrate_all(data, sel, ds, tier)
+end
+
+function calibrate_all(data::LegendData, sel::AnyValiditySelection, datastore::Union{AbstractDataStore, _NTDataStore}, tier::DataTierLike=:jldsp)
     ds = datastore
 
     @debug "Calibrating all detectors for `ValiditySelection` $(sel) in `DataTier` $(tier)"
@@ -169,7 +187,6 @@ function calibrate_all(data::LegendData, sel::AnyValiditySelection, datastore::A
     result_t = Table(NamedTuple{propertynames(result)}([if c isa StructArray Table(c) else c end for c in columns(result)]))
     return result_t, Table(pmt_events)
 end
-export calibrate_all
 
 
 _fix_vov(x) = x


### PR DESCRIPTION
## What didn't work before
`calibrate_all` only accepted an `AbstractDataStore` (an open LH5 file). The phy
event builder now reads its DSP input with `read_ldata(l200, :jldsp, fk)`, which
returns a `NamedTuple` (one entry per detector) — and there was no method for that,
so `calibrate_all(l200, fk, dsp_data)` failed to dispatch.

## Why the change is necessary
Juleana's `process_evt_phy.jl` reads jldsp via `read_ldata` and feeds the result
straight into `calibrate_all`. To keep that single-call workflow, `calibrate_all` has
to accept the `NamedTuple` that `read_ldata` returns.

## What works now
- `calibrate_all(data, sel, datastore::NamedTuple, tier=:jldsp)` is supported; the
  core `calibrate_all` body is unchanged (existing `AbstractDataStore` callers keep
  working).
- A tiny `_NTDataStore` adapter wraps the NamedTuple as a `Dict{String,Any}` keyed by
  detector and forwards `getindex` / `haskey`. The eager `Dict` conversion is
  deliberate: passing the ~120-field NamedTuple straight to `calibrate_all` would
  specialize it on that giant type and blow up LLVM compile time.

## Dependencies
Consumes `read_ldata` (LegendDataManagement). Pairs with Juleana `read-ldata-input`,
which produces the `NamedTuple` (`read_ldata(l200, :jldsp, fk)` →
`calibrate_all`). 