### PR TITLE
Update classical qc

### DIFF
--- a/src/calibrate_all.jl
+++ b/src/calibrate_all.jl
@@ -83,13 +83,13 @@ function calibrate_all(data::LegendData, sel::AnyValiditySelection, datastore::A
         trig_e_trap_ctc_cal = trig_e_trap_ctc_cal,
         trig_e_cusp_ctc_cal = trig_e_cusp_ctc_cal,
         trig_e_535_cal = trig_e_535_cal,
-        is_valid_qc = all.(map((bl, ph) -> bl .| ph, ged_events_pre.is_baseline, ged_events_pre.is_physical)),
+        is_valid_qc = all.(map((et, sp, xt) -> et .| sp .| xt, ged_events_pre.is_empty_trace, ged_events_pre.is_single_pulse, ged_events_pre.is_crosstalk)),
         is_valid_trig = is_valid_trig.(getindex.(ged_events_pre.detector, trig_e_det), Ref(hitgeds_detectors)),
         is_valid_hit = is_valid_hit,
         is_valid_psd = all.(getindex.(ged_events_pre.psd_classifier, trig_e_det)),
         is_discharge_recovery = any.(ged_events_pre.is_discharge_recovery_ml),
-        is_saturated = any.(ged_events_pre.is_saturated),
-        is_discharge = any.(ged_events_pre.is_discharge),
+        is_saturated_high = any.(ged_events_pre.is_saturated_high),
+        is_saturated_low = any.(ged_events_pre.is_saturated_low),
     )
     ged_events = StructVector(merge(columns(ged_events_pre), ged_additional_cols))
 

--- a/src/calibrate_geds.jl
+++ b/src/calibrate_geds.jl
@@ -18,6 +18,7 @@ function calibrate_ged_detector_data(data::LegendData, sel::AnyValiditySelection
         keep_detdata::Bool=false)
     
     detector = DetectorId(detector)
+    chinfo = channelinfo(data, sel, detector)
 
     # get all detdata
     detdata = detector_data[:]
@@ -30,7 +31,11 @@ function calibrate_ged_detector_data(data::LegendData, sel::AnyValiditySelection
     cut_pf = get_ged_qc_cuts_propfunc(data, sel, detector)
     
     # get qc cut functions
-    cut_is_single_pulse_pf = get_ged_qc_is_single_pulse_propfunc(data, sel, detector)
+    if chinfo.usability == :ac
+        cut_is_single_pulse_pf = get_ged_qc_is_single_pulse_ac_propfunc(data, sel, detector)
+    else
+        cut_is_single_pulse_pf = get_ged_qc_is_single_pulse_propfunc(data, sel, detector)
+    end
     cut_is_empty_trace_pf = get_ged_qc_is_empty_trace_propfunc(data, sel, detector)
     cut_is_crosstalk_pf = get_ged_qc_is_crosstalk_propfunc(data, sel, detector)
     cut_is_trig_pf = get_ged_qc_is_trig_propfunc(data, sel, detector)

--- a/src/calibrate_geds.jl
+++ b/src/calibrate_geds.jl
@@ -30,8 +30,9 @@ function calibrate_ged_detector_data(data::LegendData, sel::AnyValiditySelection
     cut_pf = get_ged_qc_cuts_propfunc(data, sel, detector)
     
     # get qc cut functions
-    cut_is_physical_pf = get_ged_qc_is_physical_propfunc(data, sel, detector)
-    cut_is_baseline_pf = get_ged_qc_is_baseline_propfunc(data, sel, detector)
+    cut_is_single_pulse_pf = get_ged_qc_is_single_pulse_propfunc(data, sel, detector)
+    cut_is_empty_trace_pf = get_ged_qc_is_empty_trace_propfunc(data, sel, detector)
+    cut_is_crosstalk_pf = get_ged_qc_is_crosstalk_propfunc(data, sel, detector)
     cut_is_trig_pf = get_ged_qc_is_trig_propfunc(data, sel, detector)
     
     # get additional cols to be parsed into the event tier
@@ -66,14 +67,16 @@ function calibrate_ged_detector_data(data::LegendData, sel::AnyValiditySelection
     detdata_output = detdata_output_pf.(detdata)
 
     # get qc cut flags
-    is_physical = cut_is_physical_pf.(cut_output)
-    is_baseline = cut_is_baseline_pf.(cut_output)
-    is_physical_trig = cut_is_trig_pf.(cal_detdata) .&& is_physical
+    is_single_pulse = cut_is_single_pulse_pf.(cut_output)
+    is_empty_trace = cut_is_empty_trace_pf.(cut_output)
+    is_crosstalk = cut_is_crosstalk_pf.(cut_output)
+    is_physical_trig = cut_is_trig_pf.(cal_detdata) .&& is_single_pulse
 
     
     additional_qc_cols = (
-        is_physical = is_physical,
-        is_baseline = is_baseline,
+        is_single_pulse = is_single_pulse,
+        is_empty_trace = is_empty_trace,
+        is_crosstalk = is_crosstalk,
         is_physical_trig = is_physical_trig,
     )
 


### PR DESCRIPTION
This PR renames some of the qc labels used in the event tier.
I also added the functionality to use a different `is_single_pulse` property function for `ac` detectors.